### PR TITLE
"Perfect" circle

### DIFF
--- a/src/scss/components/badge.scss
+++ b/src/scss/components/badge.scss
@@ -1,13 +1,15 @@
 .badge {
     display: inline-block;
-    font-size: 75%;
+    font-size: .75em;
     font-weight: 700;
     line-height: 1;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
-    border-radius:100%;
-    padding: 2px 5px;
+    border-radius: 50%;
+    padding: 5px;
+    width: 1em;
+    height: 1em;
 }
 
                             


### PR DESCRIPTION
resolve issue Fix badge style #23
I guess the "perfect circle" should be done with `clip-path: circle(50%);`, but it has some drawbacks:

-  Decent but less consistent support (https://caniuse.com/#feat=mdn-css_properties_clip-path)
- Clip paths do not impact the element’s layout, which means they will not affect borders and will likely hide outer shadows.

[this is how it looks with new styles](https://i.gyazo.com/0c8ab7e5232bff8c955751d78175ab9e.png)
I'm not sure if this kind of badges should be circle, i think they should be more of a pill shaped, but that's just my opinion :)